### PR TITLE
security(): bump dependencies (March 2025)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,8 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "com.ensono.stacks.*"
+        versions: ["*-PR"]
+    open-pull-requests-limit: 50
     rebase-strategy: disabled

--- a/java/.vscode/settings.json
+++ b/java/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive",
+  "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.ensono.stacks.modules</groupId>
     <artifactId>stacks-modules-parent</artifactId>
-    <version>3.0.59</version>
+    <version>3.0.61</version>
   </parent>
 
   <artifactId>stacks-core-commons</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.ensono.stacks.modules</groupId>
     <artifactId>stacks-modules-parent</artifactId>
-    <version>3.0.52</version>
+    <version>3.0.59</version>
   </parent>
 
   <artifactId>stacks-core-commons</artifactId>
@@ -16,7 +16,7 @@
   <description>Common components for the Java Stacks solution</description>
 
   <properties>
-    <spring-context.version>6.1.13</spring-context.version>
+    <spring-context.version>6.2.2</spring-context.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- `com.ensono.stacks.modules.stacks-modules-parent`: 3.0.52 → 3.0.59
- `org.springframework.spring-context`: 6.1.3 → 6.2.2
- Pulled `dependabot.yml` config from @ElvenSpellmaker's PR #31 