### PR TITLE
chore(): bump vm_pool_image from 20.04 → 24.04

### DIFF
--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -83,7 +83,7 @@ variables:
 
   # DEFAULT IMAGE RUNNER
   - name: pool_vm_image
-    value: ubuntu-20.04
+    value: ubuntu-24.04
 
   # Maven
   - name: maven_package_version


### PR DESCRIPTION
Updates the Azure DevOps VM pool image from Ubuntu 20.04 to Ubuntu 24.04 due to the removal of the 20.04 image from Azure DevOps. The change ensures continued compatibility with the CI/CD pipeline while leveraging a newer Ubuntu version that has been validated on other Java projects.

- Updated the default VM pool image to use Ubuntu 24.04 instead of the deprecated 20.04 version